### PR TITLE
ci(workflow): add gh-pages actions

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,26 @@
+name: GitHub Pages
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install
+        run: |
+          yarn --version
+          yarn install
+          yarn run docs
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/jsdoc
+          full_commit_message: 'docs: update documentation [skip ci]'


### PR DESCRIPTION
Based on `release` event, the JSDoc documentation is automatically
updated and deploy with GitHub Pages.

Relates #1 

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>